### PR TITLE
Remove rpmbuild options as these will be on by default

### DIFF
--- a/bdist_rpm.sh
+++ b/bdist_rpm.sh
@@ -14,5 +14,5 @@ GITTAG=$(git log --format=%ct.%h -1)
 mkdir -p BUILD SOURCES SPECS RPMS BUILDROOT
 git archive --format=tar.gz -o "SOURCES/slurm-${SUFFIX}.tar.gz" --prefix="slurm-${SUFFIX}/" HEAD
 cp slurm.spec "SPECS"
-rpmbuild --define "gittag ${GITTAG}" --define "_topdir $PWD" -ba SPECS/slurm.spec --with=mysql --with=lua --with=hwloc --with=numa
+rpmbuild --define "gittag ${GITTAG}" --define "_topdir $PWD" -ba SPECS/slurm.spec
 


### PR DESCRIPTION
... relies on the packages being installed on regice, see https://github.ugent.be/hpcugent/quattor/pull/2153