### PR TITLE
actually pass original command arguments to submitfilter rather than an empty array in qsub wrapper (HPC-7042)

### DIFF
--- a/contribs/torque/qsub.pl
+++ b/contribs/torque/qsub.pl
@@ -163,8 +163,11 @@ sub make_command
         $help,
         $resp,
         $man,
-        @pass
+        @pass,
+        @script_args
         );
+
+    @script_args = (@ARGV);
 
     GetOptions(
         'a=s'      => \$start_time,
@@ -224,7 +227,7 @@ sub make_command
     }
 
     # Use sole remaining argument as jobIds
-    my ($script, @script_args, $script_cmd, $defaults);
+    my ($script, $script_cmd, $defaults);
     my $mode = 0;
 
     $mode |= DRYRUN if $dryrun;
@@ -232,7 +235,6 @@ sub make_command
     if ($ARGV[0]) {
         $script = shift(@ARGV);
         $defaults->{J} = basename($script) if ! $job_name;
-        @script_args = (@ARGV);
         $script_cmd = join(" ", $script, @script_args);
     } else {
         $defaults->{J} = "sbatch" if ! $job_name;


### PR DESCRIPTION
The `GetOptions` call in `make_command` consumes `ARGV`, so we need to define `script_args` before calling `GetOptions` to keep track of the original arguments...