### PR TITLE
Pass the CPU count for the job to the prolog environment (HPC-7274)

### DIFF
--- a/src/common/slurm_protocol_defs.h
+++ b/src/common/slurm_protocol_defs.h
@@ -934,6 +934,8 @@ typedef struct kill_job_msg {
 	time_t   start_time;	/* time of job start, track job requeue */
 	uint32_t step_id;
 	time_t   time;		/* slurmctld's time of request */
+    uint32_t nnodes; /* Number of nodes allocated to the job */
+    uint16_t *job_node_cpus; /* Number of CPUs required on the nodes for the job */
 } kill_job_msg_t;
 
 typedef struct job_time_msg {

--- a/src/common/slurm_protocol_defs.h
+++ b/src/common/slurm_protocol_defs.h
@@ -977,6 +977,7 @@ typedef struct prolog_launch_msg {
 	char *std_err;			/* pathname of stderr */
 	char *std_out;			/* pathname of stdout */
 	uint32_t uid;
+    uint16_t *job_node_cpus; /* Number of CPUs required on the nodes for the job */
 	char *user_name;		/* job's user name */
 	char *work_dir;			/* full pathname of working directory */
 	uint16_t x11;			/* X11 forwarding setup flags */

--- a/src/common/slurm_protocol_pack.c
+++ b/src/common/slurm_protocol_pack.c
@@ -9792,7 +9792,7 @@ _pack_job_desc_list_msg(List job_req_list, Buf buffer,
 	job_desc_msg_t *req;
 	ListIterator iter;
 	uint16_t cnt = 0;
- 
+
 	if (job_req_list)
 		cnt = list_count(job_req_list);
 	pack16(cnt, buffer);
@@ -9819,7 +9819,6 @@ _unpack_job_desc_list_msg(List *job_req_list, Buf buffer,
 	job_desc_msg_t *req;
 	uint16_t cnt = 0;
 	int i;
- 
 	*job_req_list = NULL;
 
 	safe_unpack16(&cnt, buffer);
@@ -11512,6 +11511,10 @@ _pack_prolog_launch_msg(
 
 		packstr_array(msg->spank_job_env, msg->spank_job_env_size,
 			      buffer);
+
+        xassert(msg->nnodes > 0);
+        pack16_array(msg->job_node_cpus, msg->nnodes, buffer);
+
 		slurm_cred_pack(msg->cred, buffer, protocol_version);
 		packstr(msg->user_name, buffer);
 	} else if (protocol_version >= SLURM_17_02_PROTOCOL_VERSION) {
@@ -11589,6 +11592,9 @@ _unpack_prolog_launch_msg(
 		safe_unpackstr_array(&launch_msg_ptr->spank_job_env,
 				     &launch_msg_ptr->spank_job_env_size,
 				     buffer);
+        safe_unpack16_array(&launch_msg_ptr->job_node_cpus,
+                    &launch_msg_ptr->nnodes,
+                    buffer);
 		if (!(launch_msg_ptr->cred = slurm_cred_unpack(buffer,
 							protocol_version)))
 			goto unpack_error;

--- a/src/common/slurm_protocol_pack.c
+++ b/src/common/slurm_protocol_pack.c
@@ -4924,6 +4924,7 @@ _pack_kill_job_msg(kill_job_msg_t * msg, Buf buffer, uint16_t protocol_version)
 					     protocol_version);
 		packstr_array(msg->spank_job_env, msg->spank_job_env_size,
 			      buffer);
+        pack16_array(msg->job_node_cpus, msg->nnodes, buffer);
 		pack_time(msg->start_time, buffer);
 		pack32(msg->step_id,  buffer);
 		pack_time(msg->time, buffer);
@@ -4981,6 +4982,9 @@ _unpack_kill_job_msg(kill_job_msg_t ** msg, Buf buffer,
 			goto unpack_error;
 		safe_unpackstr_array(&(tmp_ptr->spank_job_env),
 				     &tmp_ptr->spank_job_env_size, buffer);
+        safe_unpack16_array(&tmp_ptr->job_node_cpus,
+                        &tmp_ptr->nnodes,
+                        buffer);
 		safe_unpack_time(&(tmp_ptr->start_time), buffer);
 		safe_unpack32(&(tmp_ptr->step_id),  buffer);
 		safe_unpack_time(&(tmp_ptr->time), buffer);

--- a/src/slurmctld/node_scheduler.c
+++ b/src/slurmctld/node_scheduler.c
@@ -2796,6 +2796,8 @@ extern void launch_prolog(struct job_record *job_ptr)
 		return;
 #endif
 
+	xassert(job_ptr->job_resrcs);
+	job_resrcs_ptr = job_ptr->job_resrcs;
 	prolog_msg_ptr = xmalloc(sizeof(prolog_launch_msg_t));
 
 	/* Locks: Write job */
@@ -2811,6 +2813,8 @@ extern void launch_prolog(struct job_record *job_ptr)
 	prolog_msg_ptr->user_name = xstrdup(job_ptr->user_name);
 	prolog_msg_ptr->alias_list = xstrdup(job_ptr->alias_list);
 	prolog_msg_ptr->nodes = xstrdup(job_ptr->nodes);
+    prolog_msg_ptr->nnodes = job_resrcs_ptr->nhosts;
+    prolog_msg_ptr->job_node_cpus = job_resrcs_ptr->cpus;
 	prolog_msg_ptr->partition = xstrdup(job_ptr->partition);
 	prolog_msg_ptr->std_err = xstrdup(job_ptr->details->std_err);
 	prolog_msg_ptr->std_out = xstrdup(job_ptr->details->std_out);
@@ -2825,8 +2829,6 @@ extern void launch_prolog(struct job_record *job_ptr)
 	prolog_msg_ptr->spank_job_env = xduparray(job_ptr->spank_job_env_size,
 						  job_ptr->spank_job_env);
 
-	xassert(job_ptr->job_resrcs);
-	job_resrcs_ptr = job_ptr->job_resrcs;
 	memset(&cred_arg, 0, sizeof(slurm_cred_arg_t));
 	cred_arg.jobid               = job_ptr->job_id;
 	cred_arg.stepid              = SLURM_EXTERN_CONT;

--- a/src/slurmctld/node_scheduler.c
+++ b/src/slurmctld/node_scheduler.c
@@ -468,6 +468,7 @@ extern void deallocate_nodes(struct job_record *job_ptr, bool timeout,
 	agent_arg_t *agent_args = NULL;
 	int down_node_cnt = 0;
 	struct node_record *node_ptr;
+	job_resources_t *job_resrcs_ptr;
 #ifdef HAVE_FRONT_END
 	front_end_record_t *front_end_ptr;
 #endif
@@ -512,6 +513,9 @@ extern void deallocate_nodes(struct job_record *job_ptr, bool timeout,
 	kill_job->spank_job_env = xduparray(job_ptr->spank_job_env_size,
 					    job_ptr->spank_job_env);
 	kill_job->spank_job_env_size = job_ptr->spank_job_env_size;
+    job_resrcs_ptr = job_ptr->job_resrcs;
+    kill_job->nnodes = job_resrcs_ptr->nhosts;
+    kill_job->job_node_cpus = job_resrcs_ptr->cpus;
 
 #ifdef HAVE_FRONT_END
 	if (job_ptr->batch_host &&

--- a/src/slurmd/slurmd/req.c
+++ b/src/slurmd/slurmd/req.c
@@ -5123,6 +5123,7 @@ _rpc_abort_job(slurm_msg_t *msg)
 							  SELECT_PRINT_RESV_ID);
 #endif
 
+    debug2("Calling _run_epilog from _rpc_abort_job");
 	_run_epilog(&job_env);
 
 	if (container_g_delete(req->job_id))
@@ -5218,6 +5219,7 @@ _rpc_terminate_batch_job(uint32_t job_id, uint32_t user_id, char *node_name)
 	job_env.node_list = node_name;
 	job_env.uid = (uid_t)user_id;
 	/* NOTE: We lack the job's SPANK environment variables */
+    debug2("Calling _run_epilog from _rpc_terminate_batch_job");
 	rc = _run_epilog(&job_env);
 	if (rc) {
 		int term_sig = 0, exit_status = 0;
@@ -5350,6 +5352,7 @@ _rpc_terminate_job(slurm_msg_t *msg)
 						      conf->auth_info);
 	int             nsteps = 0;
 	int		delay;
+    int node_inx = -1;
 //	slurm_ctl_conf_t *cf;
 //	struct stat	stat_buf;
 	job_env_t       job_env;
@@ -5558,6 +5561,9 @@ _rpc_terminate_job(slurm_msg_t *msg)
 	job_env.spank_job_env_size = req->spank_job_env_size;
 	job_env.uid = req->job_uid;
 
+    node_inx = _get_node_inx(req->nodes);
+    job_env.job_node_cpus = (node_inx >= 0 ? req->job_node_cpus[node_inx] : 0);
+    debug2("Setting job_env.job_cpu_nodes to %d", job_env.job_node_cpus);
 #if defined(HAVE_BG)
 	select_g_select_jobinfo_get(req->select_jobinfo,
 				    SELECT_JOBDATA_BLOCK_ID,
@@ -5566,6 +5572,7 @@ _rpc_terminate_job(slurm_msg_t *msg)
 	job_env.resv_id = select_g_select_jobinfo_xstrdup(
 		req->select_jobinfo, SELECT_PRINT_RESV_ID);
 #endif
+    debug2("Calling _run_epilog from _rpc_terminate_job");
 	rc = _run_epilog(&job_env);
 	xfree(job_env.resv_id);
 

--- a/src/slurmd/slurmd/req.c
+++ b/src/slurmd/slurmd/req.c
@@ -2213,7 +2213,6 @@ static void _rpc_prolog(slurm_msg_t *msg)
 		job_env.user_name = req->user_name;
 
         node_inx = _get_node_inx(req->nodes);
-        debug("_rpc_prolog: this node resides at index %d of the hostlist", node_inx);
         job_env.job_node_cpus = (node_inx >= 0 ? req->job_node_cpus[node_inx] : 0);
 #if defined(HAVE_BG)
 		select_g_select_jobinfo_get(req->select_jobinfo,
@@ -5850,6 +5849,7 @@ _build_env(job_env_t *job_env)
 	}
 
     setenvf(&env, "SLURM_JOB_NODE_CPUS", "%d", job_env->job_node_cpus);
+    setenvf(&env, "SLURM_ACTUAL_NODE_CPUS", "%d", conf->actual_cpus);
 	return env;
 }
 


### PR DESCRIPTION
- For now, only look at a single node in the recipient (slurmd)
- Add the cpu count per node in the job to the prolog RPC message
- Add the total number of nodes used to the prolog RPC message